### PR TITLE
-Removed experimental failed bluez5  bluetooth ps3 autopair script from ...

### DIFF
--- a/RetroPie/roms/settings/ps3_trust_new_controller_bluezsixaxis.sh
+++ b/RetroPie/roms/settings/ps3_trust_new_controller_bluezsixaxis.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-ps3TrustUsbControllerForBluezBluetooth.sh


### PR DESCRIPTION
...emulation station menu