### PR TITLE
-Now Intellivision emu launch command contains required sudo to run sinc...

### DIFF
--- a/.emulationstation/es_systems.cfg
+++ b/.emulationstation/es_systems.cfg
@@ -113,7 +113,7 @@
         <name>intellivision</name>
         <path>~/RetroPie/roms/intellivision</path>
         <extension>.int .INT .bin .BIN</extension>
-        <command>/opt/retropie/supplementary/runcommand/runcommand.sh 0 "/opt/retropie/emulators/jzintv/bin/jzintv -z1 -f1 -q %ROM%" "jzintv"</command>
+        <command>/opt/retropie/supplementary/runcommand/runcommand.sh 0 "sudo /opt/retropie/emulators/jzintv/bin/jzintv -z1 -f1 -q %ROM%" "jzintv"</command>
         <platform>intellivision</platform>
         <theme/>
     </system>


### PR DESCRIPTION
...e it insists on having roms in a root-owned folder