### PR TITLE
-Going back to using RetroPie 2.5 beta as a base image, could not seem t...

### DIFF
--- a/bin/installBluezPs3Driver.sh
+++ b/bin/installBluezPs3Driver.sh
@@ -2,8 +2,9 @@
 
 cowsay -f calvin Building Bluez with PS3 sixaxis autopairing driver...
 sudo apt-get update
-sudo apt-get upgrade
+#sudo apt-get -y upgrade
 sudo apt-get -y install libusb-dev libdbus-1-dev libglib2.0-dev libusb-dev libdbus-1-dev libglib2.0-dev automake libudev-dev libical-dev libreadline-dev
+cleanupTempFiles.sh
 
 #wget https://www.kernel.org/pub/linux/bluetooth/bluez-5.19.tar.xz
 #tar xJvf bluez-5.19.tar.xz
@@ -17,15 +18,17 @@ echo Removing old Bluez...
 sudo apt-get -y remove --purge bluez
 
 echo Downloading new bluez 5...
+rm bluez-5.28.tar.xz
+rm -rf bluez-5.28
 wget https://www.kernel.org/pub/linux/bluetooth/bluez-5.28.tar.xz
 tar xJvf bluez-5.28.tar.xz
 cd bluez-5.28
 
 echo Configuring new bluez 5...
-./configure --prefix=/usr --mandir=/usr/share/man --sysconfdir=/etc --localstatedir=/var --disable-systemd --enable-sixaxis
+sudo ./configure --prefix=/usr --mandir=/usr/share/man --sysconfdir=/etc --localstatedir=/var --disable-systemd --enable-sixaxis
 
 echo Compiling new bluez 5...
-make
+sudo make
 
 echo Installing new bluez 5...
 sudo make install
@@ -36,7 +39,7 @@ echo Installing init script for bluez 5 and set to enable at startup...
 sudo cp -v ~/primestationone/reference/etc/init.d/bluetooth /etc/init.d/
 sudo chmod +x /etc/init.d/bluetooth
 sudo update-rc.d bluetooth defaults
-sudo dpkg --configure -a --force-confold
+#sudo dpkg --configure -a --force-confold
 
 sudo -s cat > /etc/udev/rules.d/10-local.rules << _EOF_
 # Set bluetooth power up and p/i scan enabled


### PR DESCRIPTION
...o get gcc to create executables on RetroPie 2.6 rpi1 image :/

-Fixed (hopefully) bluez5 ps3 driver install script