### PR TITLE
-Removed atari 7800 from splash screen as the emu was not yet ready for ...

### DIFF
--- a/reference/txt/listOfLibRetroCores.txt
+++ b/reference/txt/listOfLibRetroCores.txt
@@ -4,7 +4,7 @@
 *GameBoy <
 *GameBoy Color <
 *GameGear <
-*Atari 2600 / 7800
+*Atari 2600 
 *Atari Lynx
 *Vectrex, *Odyssey 2
 *3D0, *MAME


### PR DESCRIPTION
...primetime and was removed some time back