### PR TITLE
-New script and menu entry to (hopefully) automatically force mupen64plu...

### DIFF
--- a/RetroPie/roms/settings/emulatorSettings/n64_mupen64plus_audio_output_to_analog_3.5mm_jack.sh
+++ b/RetroPie/roms/settings/emulatorSettings/n64_mupen64plus_audio_output_to_analog_3.5mm_jack.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo n64AudioOutToAnalog.sh

--- a/bin/n64AudioOutToAnalog.sh
+++ b/bin/n64AudioOutToAnalog.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo MUST BE RUN AS ROOT - Setting mupen64plus non-libretrocore emulators to output audio to the Analog 3.5mm jack
+source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
+iniSet "OUTPUT_PORT" “1” "/opt/retropie/configs/n64/mupen64plus.cfg" >/dev/null


### PR DESCRIPTION
...s audio output to the analog 3.5mm jack.  If successful, it will not be eradicated and its counterpart (and many others) will be put in its place.