### PR TITLE
-Remove manual enforcement of bluetooth up pscan now that our recommende...

### DIFF
--- a/bin/emulationstation
+++ b/bin/emulationstation
@@ -5,9 +5,9 @@
 
 #trustAllEncounteredPs3ControllersBluez5.sh
 
-echo Ensuring bluetooth is up and scanning for PS3 controllers...
-#sudo hciconfig hci0 up piscan
-sudo hciconfig hci0 up pscan
+#echo Ensuring bluetooth is up and scanning for PS3 controllers...
+##sudo hciconfig hci0 up piscan
+#sudo hciconfig hci0 up pscan
 
 es_bin="/opt/retropie/supplementary/emulationstation/emulationstation"
 


### PR DESCRIPTION
...d ps3 driver install definitely takes care of this when an hci0 (first bt adapter) is detected upon startup or insertion (plug n pray!)