### PR TITLE
-New ES settings page entry under emulatorSettings/dreamcast_system_m…

### DIFF
--- a/RetroPie/roms/settings/emulatorSettings/dreamcast_system_menu_vmu_management.sh
+++ b/RetroPie/roms/settings/emulatorSettings/dreamcast_system_menu_vmu_management.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/opt/retropie/supplementary/runcommand/runcommand.sh 0 /opt/retropie/emulators/reicast/reicast.sh


### PR DESCRIPTION
…enu_vmu_management, launches Reicast with no ROM which results in Dreamcast system menu when no disc inserted