### PR TITLE
-Now binsnroms module installer will remove previous extracted uae4al…

### DIFF
--- a/bin/megaInstallBinsNRoms.sh
+++ b/bin/megaInstallBinsNRoms.sh
@@ -4,6 +4,7 @@ download_install_mega_module_on_the_fly binsnroms ~ 120630338 'https://mega.co.n
 reset_permissions_bios_and_roms
 
 cd ~/archive
+rm -rf uae4all
 p7zip -d uae4all.7z
 mkdir ~/RetroPie/emulators
 cp -rv uae4all ~/RetroPie/emulators/


### PR DESCRIPTION
…l amiga emu in archive folder to prevent p7zip overwrite prompt