### PR TITLE
-Now ensuring retroarch emu config includes are the last line and not…

### DIFF
--- a/RetroPie/roms/settings/rewind/rewind_disable_GLOBAL.sh
+++ b/RetroPie/roms/settings/rewind/rewind_disable_GLOBAL.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-rewindGlobalDisable.sh

--- a/RetroPie/roms/settings/rewind/rewind_enable_GLOBAL.sh
+++ b/RetroPie/roms/settings/rewind/rewind_enable_GLOBAL.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-rewindGlobalEnable.sh

--- a/bin/ensureRetroarchEmuConfigsIncludesAreLast.sh
+++ b/bin/ensureRetroarchEmuConfigsIncludesAreLast.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+echo Ensuring all RetroArch emulator individual cfg files have the master include line as the last line and nowhere else...
+source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
+PATH_TO_INCLUDED_CFG="/opt/retropie/configs/all/retroarch.cfg"
+
+for configfile in **/retroarch.cfg; do
+    if [ "$configfile" == "$PATH_TO_INCLUDED_CFG" ]
+    then
+        echo "$configfile matches the master config include, not touching this one!"
+    else
+        echo "$configfile appears to be an individual emu config, processing..."
+
+        echo "Removing any existing include retroarch config line from $configfile..."
+        sed -i '/retroarch.cfg/d' "$configfile"
+        
+        echo "Readding the master config include at the end of config file $configfile..."
+        sudo sh -c "echo '#include \"/opt/retropie/configs/all/retroarch.cfg\"\n' >> $configfile"
+    fi
+done

--- a/bin/psxAnalogDisable.sh
+++ b/bin/psxAnalogDisable.sh
@@ -8,3 +8,4 @@ iniUnset "input_libretro_device_p2" "5"
 iniConfig " = " "" "/opt/retropie/configs/all/retroarch-core-options.cfg"
 iniUnset "pcsx_rearmed_pad1type" "analog"
 iniUnset "pcsx_rearmed_pad2type" "analog"
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/psxAnalogEnable.sh
+++ b/bin/psxAnalogEnable.sh
@@ -8,3 +8,4 @@ iniSet "input_libretro_device_p2" "5"
 iniConfig " = " "" "/opt/retropie/configs/all/retroarch-core-options.cfg"
 iniSet "pcsx_rearmed_pad1type" "analog"
 iniSet "pcsx_rearmed_pad2type" "analog"
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/quickCreateFoldersAndLinksAndRemoveOldFiles.sh
+++ b/bin/quickCreateFoldersAndLinksAndRemoveOldFiles.sh
@@ -36,6 +36,9 @@ rm ~/RetroPie/roms/settings/manage_wifi.sh
 
 rm ~/RetroPie/roms/settings/system/upgrade_primestation_minimal_to_full.sh
 
+rm ~/RetroPie/roms/settings/rewind/rewind_enable_GLOBAL.sh
+rm ~/RetroPie/roms/settings/rewind/rewind_disable_GLOBAL.sh
+
 rm ~/RetroPie/roms/settings/megaModules/install_mega_module_binaries_pi1.sh
 rm ~/RetroPie/roms/settings/megaModules/install_mega_module_binaries_pi2.sh
 rm ~/RetroPie/roms/settings/megaModules/install_all_mega_modules.sh
@@ -52,6 +55,8 @@ sudo rm /usr/local/bin/megaInstallOtherEmulatorsBinaries.sh
 sudo rm /usr/local/bin/megaFixRewindWithOlderRetroArch.sh
 sudo rm /usr/local/bin/retroPieNukeAndCheckoutFresh.sh
 sudo rm /usr/local/bin/sixpair
+sudo rm /usr/local/bin/rewindGlobalDisable.sh
+sudo rm /usr/local/bin/rewindGlobalEnable.sh
 
 echo Creating required folders...
 mkdir ~/temp
@@ -68,3 +73,6 @@ sudo ln -sv /home/pi/RetroPie/BIOS/cavestory /opt/retropie/libretrocores/lr-nxen
 sudo ln -sv /home/pi/RetroPie/roms/pc /opt/retropie/emulators/rpix86/games
 sudo ln -sv /home/pi/RetroPie/BIOS/dc_boot.bin /home/pi/.reicast/data/dc_boot.bin
 sudo ln -sv /home/pi/RetroPie/BIOS/dc_flash.bin /home/pi/.reicast/data/dc_flash.bin
+
+echo Ensuring retroarch emu configs have their includes as the last line
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/rewindAtari2600Disable.sh
+++ b/bin/rewindAtari2600Disable.sh
@@ -7,5 +7,6 @@ cowsay -f eyes "$message"
 source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
 iniConfig " = " "" "/opt/retropie/configs/atari2600/retroarch.cfg"
 iniSet "rewind_enable" "false"
-iniSet "rewind_buffer_size" "20"
-iniSet "rewind_granularity" "2"
+iniUnset "rewind_buffer_size" "20"
+iniUnset "rewind_granularity" "2"
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/rewindAtari2600Enable.sh
+++ b/bin/rewindAtari2600Enable.sh
@@ -7,5 +7,6 @@ cowsay -f eyes "$message"
 source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
 iniConfig " = " "" "/opt/retropie/configs/atari2600/retroarch.cfg"
 iniSet "rewind_enable" "true"
-iniSet "rewind_buffer_size" "20"
-iniSet "rewind_granularity" "2"
+iniUnset "rewind_buffer_size" "20"
+iniUnset "rewind_granularity" "2"
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/rewindGameboyColorDisable.sh
+++ b/bin/rewindGameboyColorDisable.sh
@@ -7,5 +7,6 @@ cowsay -f eyes "$message"
 source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
 iniConfig " = " "" "/opt/retropie/configs/gbc/retroarch.cfg"
 iniSet "rewind_enable" "false"
-iniSet "rewind_buffer_size" "20"
-iniSet "rewind_granularity" "2"
+iniUnset "rewind_buffer_size" "20"
+iniUnset "rewind_granularity" "2"
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/rewindGameboyColorEnable.sh
+++ b/bin/rewindGameboyColorEnable.sh
@@ -7,5 +7,6 @@ cowsay -f eyes "$message"
 source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
 iniConfig " = " "" "/opt/retropie/configs/gbc/retroarch.cfg"
 iniSet "rewind_enable" "true"
-iniSet "rewind_buffer_size" "20"
-iniSet "rewind_granularity" "2"
+iniUnset "rewind_buffer_size" "20"
+iniUnset "rewind_granularity" "2"
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/rewindGameboyDisable.sh
+++ b/bin/rewindGameboyDisable.sh
@@ -7,5 +7,6 @@ cowsay -f eyes "$message"
 source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
 iniConfig " = " "" "/opt/retropie/configs/gb/retroarch.cfg"
 iniSet "rewind_enable" "false"
-iniSet "rewind_buffer_size" "20"
-iniSet "rewind_granularity" "2"
+iniUnset "rewind_buffer_size" "20"
+iniUnset "rewind_granularity" "2"
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/rewindGameboyEnable.sh
+++ b/bin/rewindGameboyEnable.sh
@@ -7,5 +7,6 @@ cowsay -f eyes "$message"
 source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
 iniConfig " = " "" "/opt/retropie/configs/gb/retroarch.cfg"
 iniSet "rewind_enable" "true"
-iniSet "rewind_buffer_size" "20"
-iniSet "rewind_granularity" "2"
+iniUnset "rewind_buffer_size" "20"
+iniUnset "rewind_granularity" "2"
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/rewindGamegearDisable.sh
+++ b/bin/rewindGamegearDisable.sh
@@ -7,5 +7,6 @@ cowsay -f eyes "$message"
 source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
 iniConfig " = " "" "/opt/retropie/configs/gamegear/retroarch.cfg"
 iniSet "rewind_enable" "false"
-iniSet "rewind_buffer_size" "20"
-iniSet "rewind_granularity" "2"
+iniUnset "rewind_buffer_size" "20"
+iniUnset "rewind_granularity" "2"
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/rewindGamegearEnable.sh
+++ b/bin/rewindGamegearEnable.sh
@@ -7,5 +7,6 @@ cowsay -f eyes "$message"
 source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
 iniConfig " = " "" "/opt/retropie/configs/gamegear/retroarch.cfg"
 iniSet "rewind_enable" "true"
-iniSet "rewind_buffer_size" "20"
-iniSet "rewind_granularity" "2"
+iniUnset "rewind_buffer_size" "20"
+iniUnset "rewind_granularity" "2"
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/rewindGenesisDisable.sh
+++ b/bin/rewindGenesisDisable.sh
@@ -7,5 +7,6 @@ cowsay -f eyes "$message"
 source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
 iniConfig " = " "" "/opt/retropie/configs/megadrive/retroarch.cfg"
 iniSet "rewind_enable" "false"
-iniSet "rewind_buffer_size" "20"
-iniSet "rewind_granularity" "2"
+iniUnset "rewind_buffer_size" "20"
+iniUnset "rewind_granularity" "2"
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/rewindGenesisEnable.sh
+++ b/bin/rewindGenesisEnable.sh
@@ -7,5 +7,6 @@ cowsay -f eyes "$message"
 source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
 iniConfig " = " "" "/opt/retropie/configs/megadrive/retroarch.cfg"
 iniSet "rewind_enable" "true"
-iniSet "rewind_buffer_size" "20"
-iniSet "rewind_granularity" "2"
+iniUnset "rewind_buffer_size" "20"
+iniUnset "rewind_granularity" "2"
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/rewindGlobalDisable.sh
+++ b/bin/rewindGlobalDisable.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-message="Disabling global emulation rewind feature which may cause massive slowdown just being on for certain games and emus..."
-echo "$message"
-cowsay -f eyes "$message"
-
-source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
-iniConfig " = " "" "/opt/retropie/configs/all/retroarch.cfg"
-iniSet "rewind_enable" "false"

--- a/bin/rewindGlobalEnable.sh
+++ b/bin/rewindGlobalEnable.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-message="Enabling global emulation rewind feature which may cause massive slowdown just being on for certain games and emus..."
-echo "$message"
-cowsay -f eyes "$message"
-
-source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
-iniConfig " = " "" "/opt/retropie/configs/all/retroarch.cfg"
-iniSet "rewind_enable" "true"

--- a/bin/rewindGlobalLongerCoarseBuffer.sh
+++ b/bin/rewindGlobalLongerCoarseBuffer.sh
@@ -8,3 +8,4 @@ source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
 iniConfig " = " "" "/opt/retropie/configs/all/retroarch.cfg"
 iniSet "rewind_buffer_size" "100"
 iniSet "rewind_granularity" "10"
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/rewindGlobalShorterFineBuffer.sh
+++ b/bin/rewindGlobalShorterFineBuffer.sh
@@ -8,3 +8,4 @@ source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
 iniConfig " = " "" "/opt/retropie/configs/all/retroarch.cfg"
 iniSet "rewind_buffer_size" "40"
 iniSet "rewind_granularity" "2"
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/rewindGlobalToggleUnset.sh
+++ b/bin/rewindGlobalToggleUnset.sh
@@ -7,3 +7,4 @@ cowsay -f eyes "$message"
 source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
 iniConfig " = " "" "/opt/retropie/configs/all/retroarch.cfg"
 iniUnset "rewind_enable" "false"
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/rewindMastersystemDisable.sh
+++ b/bin/rewindMastersystemDisable.sh
@@ -7,5 +7,6 @@ cowsay -f eyes "$message"
 source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
 iniConfig " = " "" "/opt/retropie/configs/mastersystem/retroarch.cfg"
 iniSet "rewind_enable" "false"
-iniSet "rewind_buffer_size" "20"
-iniSet "rewind_granularity" "2"
+iniUnset "rewind_buffer_size" "20"
+iniUnset "rewind_granularity" "2"
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/rewindMastersystemEnable.sh
+++ b/bin/rewindMastersystemEnable.sh
@@ -7,5 +7,6 @@ cowsay -f eyes "$message"
 source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
 iniConfig " = " "" "/opt/retropie/configs/mastersystem/retroarch.cfg"
 iniSet "rewind_enable" "true"
-iniSet "rewind_buffer_size" "20"
-iniSet "rewind_granularity" "2"
+iniUnset "rewind_buffer_size" "20"
+iniUnset "rewind_granularity" "2"
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/rewindN64Disable.sh
+++ b/bin/rewindN64Disable.sh
@@ -7,5 +7,6 @@ cowsay -f eyes "$message"
 source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
 iniConfig " = " "" "/opt/retropie/configs/n64/retroarch.cfg"
 iniSet "rewind_enable" "false"
-iniSet "rewind_buffer_size" "20"
-iniSet "rewind_granularity" "2"
+iniUnset "rewind_buffer_size" "20"
+iniUnset "rewind_granularity" "2"
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/rewindN64Enable.sh
+++ b/bin/rewindN64Enable.sh
@@ -7,5 +7,6 @@ cowsay -f eyes "$message"
 source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
 iniConfig " = " "" "/opt/retropie/configs/n64/retroarch.cfg"
 iniSet "rewind_enable" "true"
-iniSet "rewind_buffer_size" "20"
-iniSet "rewind_granularity" "2"
+iniUnset "rewind_buffer_size" "20"
+iniUnset "rewind_granularity" "2"
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/rewindNesDisable.sh
+++ b/bin/rewindNesDisable.sh
@@ -7,5 +7,6 @@ cowsay -f eyes "$message"
 source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
 iniConfig " = " "" "/opt/retropie/configs/nes/retroarch.cfg"
 iniSet "rewind_enable" "false"
-iniSet "rewind_buffer_size" "20"
-iniSet "rewind_granularity" "2"
+iniUnset "rewind_buffer_size" "20"
+iniUnset "rewind_granularity" "2"
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/rewindNesEnable.sh
+++ b/bin/rewindNesEnable.sh
@@ -7,5 +7,6 @@ cowsay -f eyes "$message"
 source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
 iniConfig " = " "" "/opt/retropie/configs/nes/retroarch.cfg"
 iniSet "rewind_enable" "true"
-iniSet "rewind_buffer_size" "20"
-iniSet "rewind_granularity" "2"
+iniUnset "rewind_buffer_size" "20"
+iniUnset "rewind_granularity" "2"
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/rewindPsxDisable.sh
+++ b/bin/rewindPsxDisable.sh
@@ -7,5 +7,6 @@ cowsay -f eyes "$message"
 source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
 iniConfig " = " "" "/opt/retropie/configs/psx/retroarch.cfg"
 iniSet "rewind_enable" "false"
-iniSet "rewind_buffer_size" "20"
-iniSet "rewind_granularity" "2"
+iniSet "rewind_buffer_size" "100"
+iniSet "rewind_granularity" "240"
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/rewindPsxEnable.sh
+++ b/bin/rewindPsxEnable.sh
@@ -7,5 +7,6 @@ cowsay -f eyes "$message"
 source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
 iniConfig " = " "" "/opt/retropie/configs/psx/retroarch.cfg"
 iniSet "rewind_enable" "true"
-iniSet "rewind_buffer_size" "20"
-iniSet "rewind_granularity" "2"
+iniSet "rewind_buffer_size" "100"
+iniSet "rewind_granularity" "240"
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/rewindSnesDisable.sh
+++ b/bin/rewindSnesDisable.sh
@@ -7,5 +7,6 @@ cowsay -f eyes "$message"
 source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
 iniConfig " = " "" "/opt/retropie/configs/snes/retroarch.cfg"
 iniSet "rewind_enable" "false"
-iniSet "rewind_buffer_size" "20"
-iniSet "rewind_granularity" "2"
+iniUnset "rewind_buffer_size" "20"
+iniUnset "rewind_granularity" "2"
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/rewindSnesEnable.sh
+++ b/bin/rewindSnesEnable.sh
@@ -7,5 +7,6 @@ cowsay -f eyes "$message"
 source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
 iniConfig " = " "" "/opt/retropie/configs/snes/retroarch.cfg"
 iniSet "rewind_enable" "true"
-iniSet "rewind_buffer_size" "20"
-iniSet "rewind_granularity" "2"
+iniUnset "rewind_buffer_size" "20"
+iniUnset "rewind_granularity" "2"
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/rewindTg16Disable.sh
+++ b/bin/rewindTg16Disable.sh
@@ -7,5 +7,6 @@ cowsay -f eyes "$message"
 source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
 iniConfig " = " "" "/opt/retropie/configs/pcengine/retroarch.cfg"
 iniSet "rewind_enable" "false"
-iniSet "rewind_buffer_size" "20"
-iniSet "rewind_granularity" "2"
+iniUnset "rewind_buffer_size" "20"
+iniUnset "rewind_granularity" "2"
+ensureRetroarchEmuConfigsIncludesAreLast.sh

--- a/bin/rewindTg16Enable.sh
+++ b/bin/rewindTg16Enable.sh
@@ -7,5 +7,6 @@ cowsay -f eyes "$message"
 source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
 iniConfig " = " "" "/opt/retropie/configs/pcengine/retroarch.cfg"
 iniSet "rewind_enable" "true"
-iniSet "rewind_buffer_size" "20"
-iniSet "rewind_granularity" "2"
+iniUnset "rewind_buffer_size" "20"
+iniUnset "rewind_granularity" "2"
+ensureRetroarchEmuConfigsIncludesAreLast.sh


### PR DESCRIPTION
… anywhere else, which causes confusion over which setting to use

-Removed more obsolete and possibly confusing scripts / ES entries