### PR TITLE
-New scripts to enable and disable PSX emulator's auto load and save …

### DIFF
--- a/RetroPie/roms/settings/emulatorSettings/auto_save_and_restore_states_disable_for_psx_emulator.sh
+++ b/RetroPie/roms/settings/emulatorSettings/auto_save_and_restore_states_disable_for_psx_emulator.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+autoSaveAndRestoreStatesDisableForPsxEmulator.sh

--- a/RetroPie/roms/settings/emulatorSettings/auto_save_and_restore_states_enable_for_psx_emulator.sh
+++ b/RetroPie/roms/settings/emulatorSettings/auto_save_and_restore_states_enable_for_psx_emulator.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+autoSaveAndRestoreStatesEnableForPsxEmulator.sh

--- a/bin/autoSaveAndRestoreStatesDisableForAllEmulators.sh
+++ b/bin/autoSaveAndRestoreStatesDisableForAllEmulators.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-echo Setting psx analog controls enabled...
+echo Disabling auto save and restore states for all emulators...
 source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
 iniConfig " = " "" "/opt/retropie/configs/all/retroarch.cfg"
 iniUnset "savestate_auto_save" "true"

--- a/bin/autoSaveAndRestoreStatesDisableForPsxEmulator.sh
+++ b/bin/autoSaveAndRestoreStatesDisableForPsxEmulator.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo Setting psx auto save and restore states disabled...
+source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
+iniConfig " = " "" "/opt/retropie/configs/psx/retroarch.cfg"
+iniSet "savestate_auto_save" "false"
+iniSet "savestate_auto_load" "false"

--- a/bin/autoSaveAndRestoreStatesEnableForPsxEmulator.sh
+++ b/bin/autoSaveAndRestoreStatesEnableForPsxEmulator.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-echo Enabling auto save and restore states for all emulators...
+echo Setting psx auto save and restore states enabled...
 source "/home/pi/RetroPie-Setup/scriptmodules/helpers.sh"
-iniConfig " = " "" "/opt/retropie/configs/all/retroarch.cfg"
+iniConfig " = " "" "/opt/retropie/configs/psx/retroarch.cfg"
 iniSet "savestate_auto_save" "true"
 iniSet "savestate_auto_load" "true"


### PR DESCRIPTION
…state upon enter / exit since this causes some issues at times, especially if the user accidentally resets the console and gets stuck at the system menu