### PR TITLE
New menu items to install either the Sony-only PS3 controller driver,…

### DIFF
--- a/RetroPie/roms/settings/controller/install_ps3_generic_friendly_driver.sh
+++ b/RetroPie/roms/settings/controller/install_ps3_generic_friendly_driver.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+installPs3GenericFriendlyDriver.sh

--- a/RetroPie/roms/settings/controller/install_ps3_sony_only_driver.sh
+++ b/RetroPie/roms/settings/controller/install_ps3_sony_only_driver.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+installPs3SonyOnlyDriver.sh

--- a/bin/installPs3GenericFriendlyDriver.sh
+++ b/bin/installPs3GenericFriendlyDriver.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+source "/home/pi/primestationone/reference/lib/primestation_bash_functions.sh"
+fancy_console_message "Installing recommended PS3 controller drivers..." "bud-frogs"
+
+echo Cleaning up and preparing to install the PS3 controller driver fresh...
+
+echo Ensuring package management autofixes are applied if any are needed...
+sudo dpkg --configure -a
+sudo apt-get -fy install
+
+sudo service sixad stop
+
+echo Removing old driver...
+sudo dpkg --remove sixad
+sudo dpkg --remove qtsixa
+sudo rm /usr/local/bin/sixpair
+
+
+
+echo Now actually installing the recommended driver...
+#sudo ~/RetroPie-Setup/retropie_packages.sh ps3controller
+#installPs3DriverQtSixAdWithGasiaSupportFromSources.sh
+installPs3DriverQtSixAdWithFakeSupportFromSources.sh

--- a/bin/installPs3SonyOnlyDriver.sh
+++ b/bin/installPs3SonyOnlyDriver.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+source "/home/pi/primestationone/reference/lib/primestation_bash_functions.sh"
+fancy_console_message "Installing recommended PS3 controller drivers..." "bud-frogs"
+
+echo Cleaning up and preparing to install the PS3 controller driver fresh...
+
+echo Ensuring package management autofixes are applied if any are needed...
+sudo dpkg --configure -a
+sudo apt-get -fy install
+
+sudo service sixad stop
+
+echo Removing old driver...
+sudo dpkg --remove sixad
+sudo dpkg --remove qtsixa
+sudo rm /usr/local/bin/sixpair
+
+
+
+echo Now actually installing the recommended driver...
+sudo ~/RetroPie-Setup/retropie_packages.sh ps3controller
+#installPs3DriverQtSixAdWithGasiaSupportFromSources.sh
+#installPs3DriverQtSixAdWithFakeSupportFromSources.sh


### PR DESCRIPTION
… or the generic-friendly PS3 controller driver that should support both but without LED support.